### PR TITLE
[job-list]Remove unused function

### DIFF
--- a/src/app/job-list/page.tsx
+++ b/src/app/job-list/page.tsx
@@ -78,15 +78,6 @@ const FineTuningJobsPage = () => {
     setFilteredJobs(jobs);
   }, [jobs]);
 
-  const handleFilterStatus = () => {
-    const succeededJobs = jobs.filter((job) => job.status === 'succeeded');
-    setFilteredJobs(succeededJobs);
-  };
-
-  const handleResetFilter = () => {
-    setFilteredJobs(jobs);
-  };
-
   useEffect(() => {
     if (isFiltered) {
       setFilteredJobs(jobs.filter((job) => job.status === 'succeeded'));


### PR DESCRIPTION
This issue tracks the removal of two unused functions from the job-list file to simplify the codebase and enhance maintainability. The functions being removed are:

1. handleFilterStatus: This function was initially used for filtering job statuses in the job list. However, due to recent changes in the filtering logic, this function is no longer being used.

2. handleResetFilter: This function was designed to reset the filter settings to their default values. With the introduction of a new, more efficient filtering mechanism, this function has become obsolete.