### PR TITLE
Fix typo in git remote command

### DIFF
--- a/.github/workflows/merge-to-debug.yml
+++ b/.github/workflows/merge-to-debug.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Try merging to debug branch
         run: |
-          git add remote degug git@github.com:OsushiGeekCamp/openai-finetuning-helper-debug.git
+          git remote add degug git@github.com:OsushiGeekCamp/openai-finetuning-helper-debug.git
           git fetch debug
           git checkout -b debug debug/debug
           if git merge main; then


### PR DESCRIPTION
Merge remote-tracking branch 'origin/main' into fix/push-debug-repo